### PR TITLE
MAINT: run afs migration modify script on already migrated repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Context / environment
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Suggested Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+<!--
+## Screenshots (if appropriate):
+-->
+
+## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive docstrings, including context and API

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,35 @@
-# EPICS generated folders
-dbd
-lib
-bin
-children/build
-db
+# Built file ignores
+O.*
 archive
 autosave
+bin
+build
+db
+dbd
+envPaths
+html
+include
+lib
+*.log
 
+# Terminal editor ignores
+*.swp
+*~
+
+# IDE ignores
+*.vscode
+
+# Core dumps
+core.*
+
+# From original afs gitignore
+# EPICS generated folders
+children/build
 # EPICS object files
 **/O.*
-
 # Generated files
 **envPaths
-
 # Python temp files
-__pycache__/
-
+__pycache__
 # Dev files
 run.sh

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,39 @@
+Copyright (c) 2024, The Board of Trustees of the Leland Stanford Junior
+University, through SLAC National Accelerator Laboratory (subject to receipt
+of any required approvals from the U.S. Dept. of Energy). All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+(1) Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+(2) Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+(3) Neither the name of the Leland Stanford Junior University, SLAC National
+    Accelerator Laboratory, U.S. Dept. of Energy nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER, THE UNITED STATES GOVERNMENT,
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+
+You are under no obligation whatsoever to provide any bug fixes, patches, or
+upgrades to the features, functionality or performance of the source code
+("Enhancements") to anyone; however, if you choose to make your Enhancements
+available either publicly, or directly to SLAC National Accelerator Laboratory,
+without imposing a separate written license agreement for such Enhancements,
+then you hereby grant the following license: a non-exclusive, royalty-free
+perpetual license to install, use, modify, prepare derivative works, incorporate
+into other computer software, distribute, and sublicense such Enhancements or
+derivative works thereof, in binary and source code form.

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-Serial communcation in my case only worked with DIGI terminal server.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
+# ioc-common-thermocon
+This is an EPICS IOC that is used at LCLS. This repo was automatically transferred to github from an internal filesystem repository via the scripts at https://github.com/pcdshub/afs_ioc_migration.
+
+The original filesystem location was /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/common/thermocon.git.
+
+
+## Original readme files
+### README
+Serial communcation in my case only worked with DIGI terminal server.
+
+### README.md
 # ioc-thermocon
+


### PR DESCRIPTION
This repo was already migrated off of afs long ago, but I still wanted to run the migration scripts on it to the extent that they apply.

See https://github.com/pcdshub/afs_ioc_migration/pull/1
See https://confluence.slac.stanford.edu/display/PCDS/ECS+EPICS+IOC+Github+Migration+Log